### PR TITLE
Add health check endpoint test

### DIFF
--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+
+def test_health_endpoint():
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- add pytest for `/health` endpoint to ensure service responds with status ok

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68af2520af048332975b9293958d1e98