### PR TITLE
Add root endpoint with optional static frontend serving

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 
 app = FastAPI(title="CoolChat")
 
@@ -11,6 +13,16 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+frontend_build = Path(__file__).resolve().parent.parent / "frontend" / "dist"
+if frontend_build.exists():
+    app.mount("/", StaticFiles(directory=frontend_build, html=True), name="frontend")
+else:
+    @app.get("/")
+    async def root():
+        """Root endpoint with a friendly message."""
+        return {"message": "Welcome to CoolChat API. Visit /docs for API documentation."}
+
 
 @app.get("/health")
 async def health_check():


### PR DESCRIPTION
## Summary
- add default route with welcome message
- optionally serve built frontend if available

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68af26788864833292075b79622563da