### PR TITLE
Add root API endpoint and optional frontend mount

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -14,14 +14,16 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+@app.get("/")
+async def root():
+    """Root endpoint with a friendly message."""
+    return {"message": "CoolChat backend running"}
+
+
 frontend_build = Path(__file__).resolve().parent.parent / "frontend" / "dist"
 if frontend_build.exists():
-    app.mount("/", StaticFiles(directory=frontend_build, html=True), name="frontend")
-else:
-    @app.get("/")
-    async def root():
-        """Root endpoint with a friendly message."""
-        return {"message": "Welcome to CoolChat API. Visit /docs for API documentation."}
+    app.mount("/app", StaticFiles(directory=frontend_build, html=True), name="frontend")
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- add root endpoint returning a JSON status message
- mount built frontend at `/app` when a compiled bundle exists

## Testing
- `pip install httpx` (fails: Could not find a version that satisfies the requirement httpx)
- `pytest` (fails: ModuleNotFoundError: No module named 'httpx')

------
https://chatgpt.com/codex/tasks/task_e_68af27a1f1b083328ea4101b23a70504