### PR TITLE
Add character card model and CRUD endpoints

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DB_PATH = Path(__file__).resolve().parent / "app.db"
+SQLALCHEMY_DATABASE_URL = f"sqlite:///{DB_PATH}"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 
+from .database import Base, engine
+from .routers import characters
+
 app = FastAPI(title="CoolChat")
 
 # Allow CORS for frontend development
@@ -13,6 +16,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+Base.metadata.create_all(bind=engine)
+app.include_router(characters.router)
 
 frontend_build = Path(__file__).resolve().parent.parent / "frontend" / "dist"
 if frontend_build.exists():

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String
+
+from .database import Base
+
+
+class CharacterCard(Base):
+    __tablename__ = "character_cards"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    avatar_url = Column(String, nullable=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+sqlalchemy
+httpx

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..database import SessionLocal
+
+router = APIRouter(prefix="/characters", tags=["characters"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/", response_model=schemas.CharacterCard)
+def create_character(card: schemas.CharacterCardCreate, db: Session = Depends(get_db)):
+    db_card = models.CharacterCard(**card.dict())
+    db.add(db_card)
+    db.commit()
+    db.refresh(db_card)
+    return db_card
+
+
+@router.get("/", response_model=list[schemas.CharacterCard])
+def read_characters(db: Session = Depends(get_db)):
+    return db.query(models.CharacterCard).all()
+
+
+@router.get("/{card_id}", response_model=schemas.CharacterCard)
+def read_character(card_id: int, db: Session = Depends(get_db)):
+    card = db.get(models.CharacterCard, card_id)
+    if not card:
+        raise HTTPException(status_code=404, detail="Character not found")
+    return card
+
+
+@router.put("/{card_id}", response_model=schemas.CharacterCard)
+def update_character(
+    card_id: int, card_update: schemas.CharacterCardCreate, db: Session = Depends(get_db)
+):
+    card = db.get(models.CharacterCard, card_id)
+    if not card:
+        raise HTTPException(status_code=404, detail="Character not found")
+    for key, value in card_update.dict().items():
+        setattr(card, key, value)
+    db.commit()
+    db.refresh(card)
+    return card
+
+
+@router.delete("/{card_id}", status_code=204)
+def delete_character(card_id: int, db: Session = Depends(get_db)):
+    card = db.get(models.CharacterCard, card_id)
+    if not card:
+        raise HTTPException(status_code=404, detail="Character not found")
+    db.delete(card)
+    db.commit()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class CharacterCardBase(BaseModel):
+    name: str
+    description: str | None = None
+    avatar_url: str | None = None
+
+
+class CharacterCardCreate(CharacterCardBase):
+    pass
+
+
+class CharacterCard(CharacterCardBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/backend/tests/test_characters.py
+++ b/backend/tests/test_characters.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+
+client = TestClient(app)
+
+
+def test_create_and_read_character():
+    payload = {
+        "name": "Alice",
+        "description": "Adventurer",
+        "avatar_url": "http://example.com/avatar.png",
+    }
+    response = client.post("/characters/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == payload["name"]
+    char_id = data["id"]
+
+    list_resp = client.get("/characters/")
+    assert list_resp.status_code == 200
+    assert any(item["id"] == char_id for item in list_resp.json())
+
+    get_resp = client.get(f"/characters/{char_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["id"] == char_id


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and Pydantic schemas for character cards
- implement /characters CRUD FastAPI router with SQLite persistence
- cover character operations with tests and update dependencies

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*
- `pytest backend/tests/test_characters.py backend/tests/test_health.py` *(fails: starlette.testclient requires httpx package)*

------
https://chatgpt.com/codex/tasks/task_e_68af282336b48332adf00060b7a8d655