### PR TITLE
Use absolute import for database module

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 
-from .database import Base, engine
+from backend.database import Base, engine
 from .routers import characters
 
 app = FastAPI(title="CoolChat")


### PR DESCRIPTION
## Summary
- reference backend.database explicitly in main module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*
- `uvicorn backend.main:app --reload` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68af2c03f3e08332ae14d875b1b79905