### PR TITLE
Add API health check badge

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,17 @@
+.status-badge {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  font-weight: bold;
+  color: #fff;
+}
+
+.status-online {
+  background-color: #28a745;
+}
+
+.status-offline {
+  background-color: #dc3545;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,29 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { checkHealth } from './api';
+import './App.css';
 
 function App() {
+  const [apiOnline, setApiOnline] = useState(null);
+
+  useEffect(() => {
+    async function fetchHealth() {
+      const ok = await checkHealth();
+      setApiOnline(ok);
+    }
+    fetchHealth();
+  }, []);
+
   return (
     <div>
       <h1>CoolChat</h1>
       <p>Welcome to CoolChat, a Python/React re-imagination of SillyTavern.</p>
+      {apiOnline !== null && (
+        <span
+          className={`status-badge ${apiOnline ? 'status-online' : 'status-offline'}`}
+        >
+          API {apiOnline ? 'online' : 'offline'}
+        </span>
+      )}
     </div>
   );
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,11 @@
+export async function checkHealth() {
+  try {
+    const res = await fetch('/health');
+    return res.ok;
+  } catch (err) {
+    console.error('Health check failed', err);
+    return false;
+  }
+}
+
+export default { checkHealth };


### PR DESCRIPTION
## Summary
- add `checkHealth` API helper for checking `/health`
- show API online/offline badge in `App`
- style status badge for visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af4a108aa883328de430ce21316459