### PR TITLE
Add simple chat echo endpoint and test

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -23,7 +23,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.mount("/", StaticFiles(directory="frontend/dist", html=True), name="static")
+app.mount("/app", StaticFiles(directory="frontend/dist", html=True), name="static")
 
 # ---------------------------------------------------------------------------
 # Models and in-memory storage
@@ -64,6 +64,29 @@ async def root():
 async def health_check():
     """Simple endpoint to confirm the service is running."""
     return {"status": "ok"}
+
+# ---------------------------------------------------------------------------
+# Chat endpoints
+# ---------------------------------------------------------------------------
+
+
+class ChatRequest(BaseModel):
+    """Payload for the chat endpoint."""
+
+    message: str
+
+
+class ChatResponse(BaseModel):
+    """Response returned after processing a chat message."""
+
+    reply: str
+
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(payload: ChatRequest) -> ChatResponse:
+    """Very small demo chat endpoint that simply echoes the message."""
+
+    return ChatResponse(reply=f"You said: {payload.message}")
 
 # ---------------------------------------------------------------------------
 # Character endpoints

--- a/backend/tests/test_chat_flow.py
+++ b/backend/tests/test_chat_flow.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_basic_chat_flow():
+    payload = {"message": "Hello"}
+    resp = client.post("/chat", json=payload)
+    assert resp.status_code == 200
+    assert resp.json() == {"reply": "You said: Hello"}

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -1,0 +1,1 @@
+<html><body>CoolChat</body></html>


### PR DESCRIPTION
## Summary
- add `/chat` endpoint that echoes back user messages
- move static frontend mount to `/app`
- test chat flow and include placeholder frontend dist file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af5290aff48332920683d3596ec329