### PR TITLE
Add basic chat UI and backend chat endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Dict, List
+import os
 
 app = FastAPI(title="CoolChat")
 
@@ -23,7 +24,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.mount("/", StaticFiles(directory="frontend/dist", html=True), name="static")
+if os.path.isdir("frontend/dist"):
+    app.mount("/", StaticFiles(directory="frontend/dist", html=True), name="static")
 
 # ---------------------------------------------------------------------------
 # Models and in-memory storage
@@ -165,3 +167,20 @@ async def delete_lore(entry_id: int) -> None:
         raise HTTPException(status_code=404, detail="Lore entry not found")
     del _lore[entry_id]
     return None
+
+# ---------------------------------------------------------------------------
+# Chat endpoint
+# ---------------------------------------------------------------------------
+
+
+class ChatMessage(BaseModel):
+    """Payload for a basic chat message."""
+
+    message: str
+
+
+@app.post("/chat")
+async def chat(payload: ChatMessage) -> Dict[str, str]:
+    """Return a trivial response echoing the user's message."""
+
+    return {"reply": f"You said: {payload.message}"}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -11,10 +11,12 @@
   }
 }
 
-ul {
+.message-list {
   list-style: none;
   padding: 0;
   margin: 0 0 1rem 0;
+  max-height: 60vh;
+  overflow-y: auto;
 }
 
 form {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,19 +1,49 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
+import './App.css';
 
 function App() {
-  const [health, setHealth] = useState('unknown');
+  const [messages, setMessages] = useState([]);
+  const [currentInput, setCurrentInput] = useState('');
 
-  useEffect(() => {
-    fetch('/health')
-      .then(() => setHealth('online'))
-      .catch(() => setHealth('offline'));
-  }, []);
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const text = currentInput.trim();
+    if (!text) return;
+
+    const userMessage = { role: 'user', text };
+    setMessages((prev) => [...prev, userMessage]);
+    setCurrentInput('');
+
+    try {
+      const res = await fetch('/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text }),
+      });
+      const data = await res.json();
+      setMessages((prev) => [...prev, { role: 'bot', text: data.reply }]);
+    } catch (err) {
+      setMessages((prev) => [...prev, { role: 'bot', text: 'Error: failed to fetch' }]);
+    }
+  };
 
   return (
     <div className="chat-container">
       <h1>CoolChat</h1>
-      <p>Welcome to CoolChat, a Python/React re-imagination of SillyTavern.</p>
-      <span>{health}</span>
+      <ul className="message-list">
+        {messages.map((m, idx) => (
+          <li key={idx} className={m.role}>{m.text}</li>
+        ))}
+      </ul>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={currentInput}
+          onChange={(e) => setCurrentInput(e.target.value)}
+          placeholder="Type your message..."
+        />
+        <button type="submit">Send</button>
+      </form>
     </div>
   );
 }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,16 +1,23 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import App from './App';
 
-describe('App', () => {
-  it('renders heading and shows offline when fetch fails', async () => {
-    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('fail'));
+describe('App chat', () => {
+  it('shows user and bot messages after sending', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ reply: 'Hi there' }),
+    });
 
     render(<App />);
 
-    expect(screen.getByRole('heading', { name: /coolchat/i })).toBeInTheDocument();
-    expect(await screen.findByText(/offline/i)).toBeInTheDocument();
+    const input = screen.getByPlaceholderText(/type your message/i);
+    fireEvent.change(input, { target: { value: 'Hello' } });
+    fireEvent.submit(input.closest('form'));
+
+    expect(await screen.findByText('Hello')).toBeInTheDocument();
+    expect(await screen.findByText('Hi there')).toBeInTheDocument();
 
     global.fetch.mockRestore();
   });


### PR DESCRIPTION
## Summary
- Build chat interface with message list and input form
- Add `/chat` endpoint to echo messages
- Introduce basic styling for mobile-friendly message pane
- Add test ensuring messages render after send

## Testing
- `npm test --prefix frontend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af5287266883328ce0a1afedc84046