### PR TITLE
feat: prefix API under /api and serve built frontend

### DIFF
--- a/backend/tests/test_characters.py
+++ b/backend/tests/test_characters.py
@@ -7,13 +7,13 @@ client = TestClient(app)
 
 def test_character_crud_cycle():
     # ensure initially empty
-    resp = client.get("/characters")
+    resp = client.get("/api/characters")
     assert resp.status_code == 200
     assert resp.json() == []
 
     # create a character
     payload = {"name": "Alice", "description": "A curious adventurer"}
-    resp = client.post("/characters", json=payload)
+    resp = client.post("/api/characters", json=payload)
     assert resp.status_code == 201
     data = resp.json()
     assert data["id"] == 1
@@ -22,14 +22,14 @@ def test_character_crud_cycle():
     char_id = data["id"]
 
     # fetch it individually
-    resp = client.get(f"/characters/{char_id}")
+    resp = client.get(f"/api/characters/{char_id}")
     assert resp.status_code == 200
     assert resp.json()["name"] == payload["name"]
 
     # delete it
-    resp = client.delete(f"/characters/{char_id}")
+    resp = client.delete(f"/api/characters/{char_id}")
     assert resp.status_code == 204
 
     # ensure gone
-    resp = client.get(f"/characters/{char_id}")
+    resp = client.get(f"/api/characters/{char_id}")
     assert resp.status_code == 404

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -6,12 +6,12 @@ client = TestClient(app)
 
 
 def test_root():
-    response = client.get("/")
+    response = client.get("/api/")
     assert response.status_code == 200
     assert response.json() == {"message": "CoolChat backend running"}
 
 
 def test_health():
-    response = client.get("/health")
+    response = client.get("/api/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}

--- a/backend/tests/test_lore.py
+++ b/backend/tests/test_lore.py
@@ -6,12 +6,12 @@ client = TestClient(app)
 
 
 def test_lore_crud_cycle():
-    resp = client.get("/lore")
+    resp = client.get("/api/lore")
     assert resp.status_code == 200
     assert resp.json() == []
 
     payload = {"keyword": "wizard", "content": "Wizards channel arcane energy"}
-    resp = client.post("/lore", json=payload)
+    resp = client.post("/api/lore", json=payload)
     assert resp.status_code == 201
     data = resp.json()
     assert data["id"] == 1
@@ -19,12 +19,12 @@ def test_lore_crud_cycle():
 
     entry_id = data["id"]
 
-    resp = client.get(f"/lore/{entry_id}")
+    resp = client.get(f"/api/lore/{entry_id}")
     assert resp.status_code == 200
     assert resp.json()["content"] == payload["content"]
 
-    resp = client.delete(f"/lore/{entry_id}")
+    resp = client.delete(f"/api/lore/{entry_id}")
     assert resp.status_code == 204
 
-    resp = client.get(f"/lore/{entry_id}")
+    resp = client.get(f"/api/lore/{entry_id}")
     assert resp.status_code == 404

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CoolChat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- group backend endpoints under a new `/api` router
- serve the built frontend from `frontend/dist` at the root
- adjust backend tests to call the `/api/...` paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af57e147ec83328e573de1fe7aa9bf