### PR TITLE
Refactor character router to use shared DB dependency and add tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -21,7 +21,7 @@ from .config import AppConfig, ProviderConfig, load_config, save_config, mask_se
 from .models import Lorebook, LoreEntry
 from .storage import load_json, save_json, public_dir
 from .database import SessionLocal
-from .routers import lore
+from .routers import lore, characters
 import os
 
 app = FastAPI(title="CoolChat")
@@ -72,8 +72,9 @@ try:
 except Exception:
     pass
 
-# Include the lore router
+# Include routers
 app.include_router(lore.router, tags=["lore"])
+app.include_router(characters.router, tags=["characters"])
 
 # Serve debug.json file for frontend access
 @app.get("/debug.json")

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -1,18 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy.orm import Session
 
 from .. import models, schemas
-from ..database import SessionLocal
+from ..database import get_db
 
 router = APIRouter(prefix="/characters", tags=["characters"])
-
-
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 @router.post("/", response_model=schemas.CharacterCard)

--- a/backend/tests/test_character_router.py
+++ b/backend/tests/test_character_router.py
@@ -1,0 +1,72 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend import models
+from backend.database import get_db
+from backend.routers import characters
+
+# Create an in-memory SQLite database for testing
+engine = create_engine(
+    "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+app.include_router(characters.router)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def test_character_router_crud_cycle():
+    # Initially empty
+    resp = client.get("/characters/")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+    # Create character
+    payload = {"name": "Alice", "description": "A curious adventurer"}
+    resp = client.post("/characters/", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == 1
+    assert data["name"] == payload["name"]
+
+    char_id = data["id"]
+
+    # Read list
+    resp = client.get("/characters/")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # Read single
+    resp = client.get(f"/characters/{char_id}")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == payload["name"]
+
+    # Update
+    update_payload = {"name": "Alice", "description": "Updated"}
+    resp = client.put(f"/characters/{char_id}", json=update_payload)
+    assert resp.status_code == 200
+    assert resp.json()["description"] == "Updated"
+
+    # Delete
+    resp = client.delete(f"/characters/{char_id}")
+    assert resp.status_code == 204
+
+    # Ensure deleted
+    resp = client.get(f"/characters/{char_id}")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Use FastAPI's dependency-injected `get_db` in character router
- Register character router in main application
- Add CRUD unit tests for character router using in-memory SQLite

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv' and others)*
- `pytest backend/tests/test_character_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfa646b3e88332be49a49534085ef6