### PR TITLE
feat: support configurable API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ A completely AI-built LLM client inspired by SillyTavern, implemented in Python 
 3. Start backend: `cd backend && python main.py`
 4. Start frontend: `cd frontend && npm run dev`
 
+### API Base URL
+
+The frontend reads an optional `VITE_API_BASE` environment variable to determine the
+base URL for API requests. During development it defaults to the same origin (handled
+by the Vite proxy). For production builds, set this variable to your backend URL:
+
+```bash
+VITE_API_BASE=https://api.example.com npm run build
+```
+
 ## Next Steps & Priority Tasks
 1. **Implement Prompt Manager & Circuits System** - Develop visual flowchart UI for managing all prompts, variables, and logic blocks with if/then/else, random choices, counters, etc.
 2. **Enhance System Prompt Editing** - Add user-editable fields for previously hardcoded text sent to AI (persona format, tool descriptions, lore injection format)

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,13 +1,15 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { vi } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import App from './App';
 
 describe('App chat', () => {
   it('shows user and bot messages after sending', async () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({ reply: 'Hi there' }),
+    vi.spyOn(global, 'fetch').mockImplementation((url) => {
+      if (typeof url === 'string' && url.endsWith('/chat')) {
+        return Promise.resolve({ ok: true, json: async () => ({ reply: 'Hi there' }) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
     });
 
     render(<App />);
@@ -18,6 +20,7 @@ describe('App chat', () => {
 
     expect(await screen.findByText('Hello')).toBeInTheDocument();
     expect(await screen.findByText('Hi there')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith('http://test/chat', expect.any(Object));
 
     global.fetch.mockRestore();
   });

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,9 @@
+// Configurable API base URL; default is same-origin for development
+export const API_BASE = (import.meta.env.VITE_API_BASE ?? '').replace(/\/$/, '');
+
 export async function checkHealth() {
   try {
-    const res = await fetch('/health');
+    const res = await fetch(`${API_BASE}/health`);
     return res.ok;
   } catch (err) {
     console.error('Health check failed', err);
@@ -9,7 +12,7 @@ export async function checkHealth() {
 }
 
 export async function sendChat(message, sessionId = 'default') {
-  const res = await fetch('/chat', {
+  const res = await fetch(`${API_BASE}/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ message, session_id: sessionId }),
@@ -24,13 +27,13 @@ export async function sendChat(message, sessionId = 'default') {
 
 // Characters API
 export async function listCharacters() {
-  const res = await fetch('/characters');
+  const res = await fetch(`${API_BASE}/characters`);
   if (!res.ok) throw new Error(`List characters failed: ${res.status}`);
   return res.json();
 }
 
 export async function createCharacter({ name, description = '', avatar_url = null }) {
-  const res = await fetch('/characters', {
+  const res = await fetch(`${API_BASE}/characters`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, description, avatar_url }),
@@ -40,12 +43,12 @@ export async function createCharacter({ name, description = '', avatar_url = nul
 }
 
 export async function deleteCharacter(id) {
-  const res = await fetch(`/characters/${id}`, { method: 'DELETE' });
+  const res = await fetch(`${API_BASE}/characters/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error(`Delete character failed: ${res.status}`);
 }
 
 export async function getConfig() {
-  const res = await fetch('/config');
+  const res = await fetch(`${API_BASE}/config`);
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`Get config failed: ${res.status} ${text}`);
@@ -54,14 +57,14 @@ export async function getConfig() {
 }
 
 export async function getConfigRaw() {
-  const res = await fetch('/config/raw');
+  const res = await fetch(`${API_BASE}/config/raw`);
   if (!res.ok) throw new Error(`Get raw config failed: ${res.status}`);
   return res.json();
 }
 
 // partial can include { active_provider, providers: { [provider]: { api_base, api_key, model, temperature } } }
 export async function updateConfig(partial) {
-  const res = await fetch('/config', {
+  const res = await fetch(`${API_BASE}/config`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(partial),
@@ -81,7 +84,7 @@ export async function updateConfig(partial) {
 
 export async function getModels(provider) {
   const qs = provider ? `?provider=${encodeURIComponent(provider)}` : '';
-  const res = await fetch(`/models${qs}`);
+  const res = await fetch(`${API_BASE}/models${qs}`);
   if (!res.ok) {
     const text = await res.text();
     try {
@@ -97,13 +100,13 @@ export async function getModels(provider) {
 
 // Lorebooks API
 export async function listLorebooks() {
-  const res = await fetch('/lorebooks/');
+  const res = await fetch(`${API_BASE}/lorebooks/`);
   if (!res.ok) throw new Error(`List lorebooks failed: ${res.status}`);
   return res.json();
 }
 
 export async function createLorebook({ name, description = '', entries = [] }) {
-  const res = await fetch('/lorebooks', {
+  const res = await fetch(`${API_BASE}/lorebooks`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, description, entries }),
@@ -115,13 +118,13 @@ export async function createLorebook({ name, description = '', entries = [] }) {
 export async function importLorebook(file) {
   const fd = new FormData();
   fd.append('file', file);
-  const res = await fetch('/lorebooks/import', { method: 'POST', body: fd });
+  const res = await fetch(`${API_BASE}/lorebooks/import`, { method: 'POST', body: fd });
   if (!res.ok) throw new Error(`Import lorebook failed: ${res.status}`);
   return res.json();
 }
 
 export async function updateCharacter(id, data) {
-  const res = await fetch(`/characters/${id}`, {
+  const res = await fetch(`${API_BASE}/characters/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
@@ -131,7 +134,7 @@ export async function updateCharacter(id, data) {
 }
 
 export async function suggestCharacterField(field, characterDraft) {
-  const res = await fetch('/characters/suggest_field', {
+  const res = await fetch(`${API_BASE}/characters/suggest_field`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ field, character: characterDraft }),
@@ -141,13 +144,13 @@ export async function suggestCharacterField(field, characterDraft) {
 }
 
 export async function getImageModels(provider) {
-  const res = await fetch(`/image/models?provider=${encodeURIComponent(provider)}`);
+  const res = await fetch(`${API_BASE}/image/models?provider=${encodeURIComponent(provider)}`);
   if (!res.ok) throw new Error(`Get image models failed: ${res.status}`);
   return res.json();
 }
 
 export async function generateImageFromChat(sessionId = 'default') {
-  const res = await fetch('/images/generate_from_chat', {
+  const res = await fetch(`${API_BASE}/images/generate_from_chat`, {
     method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ session_id: sessionId }),
   });
   if (!res.ok) throw new Error(`Generate image failed: ${res.status}`);
@@ -155,43 +158,43 @@ export async function generateImageFromChat(sessionId = 'default') {
 }
 
 export async function generateImageDirect(prompt, sessionId = 'default') {
-  const res = await fetch('/images/generate', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ prompt, session_id: sessionId }) });
+  const res = await fetch(`${API_BASE}/images/generate`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ prompt, session_id: sessionId }) });
   if (!res.ok) throw new Error(`Generate image failed: ${res.status}`);
   return res.json();
 }
 
 export async function updateLoreEntry(id, data) {
-  const res = await fetch(`/lorebooks/entries/${id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+  const res = await fetch(`${API_BASE}/lorebooks/entries/${id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
   if (!res.ok) throw new Error(`Update lore failed: ${res.status}`);
   return res.json();
 }
 
 export async function updateLorebook(id, data) {
-  const res = await fetch(`/lorebooks/${id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+  const res = await fetch(`${API_BASE}/lorebooks/${id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
   if (!res.ok) throw new Error(`Update lorebook failed: ${res.status}`);
   return res.json();
 }
 
 export async function getLorebook(id) {
-  const res = await fetch(`/lorebooks/${id}`);
+  const res = await fetch(`${API_BASE}/lorebooks/${id}`);
   if (!res.ok) throw new Error(`Get lorebook failed: ${res.status}`);
   return res.json();
 }
 
 export async function createLoreEntry(data) {
-  const res = await fetch('/lorebooks/entries', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+  const res = await fetch(`${API_BASE}/lorebooks/entries`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
   if (!res.ok) throw new Error(`Create lore entry failed: ${res.status}`);
   return res.json();
 }
 
 export async function deleteLoreEntry(id) {
-  const res = await fetch(`/lorebooks/entries/${id}`, { method: 'DELETE' });
+  const res = await fetch(`${API_BASE}/lorebooks/entries/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error(`Delete lore entry failed: ${res.status}`);
   return res.json();
 }
 
 export async function deleteLorebook(id) {
-  const res = await fetch(`/lorebooks/${id}`, { method: 'DELETE' });
+  const res = await fetch(`${API_BASE}/lorebooks/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error(`Delete lorebook failed: ${res.status}`);
   return res.json();
 }
@@ -204,13 +207,13 @@ export async function searchLorebooks(query, limit = 10, use_rag = false) {
     limit: limit.toString(),
     use_rag: use_rag.toString()
   });
-  const res = await fetch(`/lorebooks/search?${params}`);
+  const res = await fetch(`${API_BASE}/lorebooks/search?${params}`);
   if (!res.ok) throw new Error(`Search lorebooks failed: ${res.status}`);
   return res.json();
 }
 
 export async function bulkCreateLoreEntries(bulkData) {
-  const res = await fetch('/lorebooks/entries/bulk', {
+  const res = await fetch(`${API_BASE}/lorebooks/entries/bulk`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(bulkData),
@@ -220,7 +223,7 @@ export async function bulkCreateLoreEntries(bulkData) {
 }
 
 export async function linkCharacterToLorebook(characterId, lorebookId) {
-  const res = await fetch(`/lorebooks/characters/${characterId}/lorebooks/${lorebookId}`, {
+  const res = await fetch(`${API_BASE}/lorebooks/characters/${characterId}/lorebooks/${lorebookId}`, {
     method: 'POST',
   });
   if (!res.ok) throw new Error(`Link character to lorebook failed: ${res.status}`);
@@ -228,7 +231,7 @@ export async function linkCharacterToLorebook(characterId, lorebookId) {
 }
 
 export async function unlinkCharacterFromLorebook(characterId, lorebookId) {
-  const res = await fetch(`/lorebooks/characters/${characterId}/lorebooks/${lorebookId}`, {
+  const res = await fetch(`${API_BASE}/lorebooks/characters/${characterId}/lorebooks/${lorebookId}`, {
     method: 'DELETE',
   });
   if (!res.ok) throw new Error(`Unlink character from lorebook failed: ${res.status}`);
@@ -236,13 +239,13 @@ export async function unlinkCharacterFromLorebook(characterId, lorebookId) {
 }
 
 export async function getCharacterLorebooks(characterId) {
-  const res = await fetch(`/lorebooks/characters/${characterId}/lorebooks`);
+  const res = await fetch(`${API_BASE}/lorebooks/characters/${characterId}/lorebooks`);
   if (!res.ok) throw new Error(`Get character lorebooks failed: ${res.status}`);
   return res.json();
 }
 
 export async function injectLoreContext(requestData) {
-  const res = await fetch('/lorebooks/inject_context', {
+  const res = await fetch(`${API_BASE}/lorebooks/inject_context`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(requestData),
@@ -251,66 +254,66 @@ export async function injectLoreContext(requestData) {
   return res.json();
 }
 export async function listChats() {
-  const res = await fetch('/chats');
+  const res = await fetch(`${API_BASE}/chats`);
   if (!res.ok) throw new Error(`List chats failed: ${res.status}`);
   return res.json(); // { sessions: string[] }
 }
 export async function getChat(sessionId) {
-  const res = await fetch(`/chats/${encodeURIComponent(sessionId)}`);
+  const res = await fetch(`${API_BASE}/chats/${encodeURIComponent(sessionId)}`);
   if (!res.ok) throw new Error(`Get chat failed: ${res.status}`);
   return res.json(); // { messages: [{role, content}] }
 }
 export async function resetChat(sessionId) {
-  const res = await fetch(`/chats/${encodeURIComponent(sessionId)}/reset`, { method: 'POST' });
+  const res = await fetch(`${API_BASE}/chats/${encodeURIComponent(sessionId)}/reset`, { method: 'POST' });
   if (!res.ok) throw new Error(`Reset chat failed: ${res.status}`);
   return res.json();
 }
 
 // Prompts
 export async function getPrompts() {
-  const res = await fetch('/prompts');
+  const res = await fetch(`${API_BASE}/prompts`);
   if (!res.ok) throw new Error(`Get prompts failed: ${res.status}`);
   return res.json();
 }
 export async function savePrompts(data) {
-  const res = await fetch('/prompts', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+  const res = await fetch(`${API_BASE}/prompts`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
   if (!res.ok) throw new Error(`Save prompts failed: ${res.status}`);
   return res.json();
 }
 
 // Lore suggestions
 export async function suggestLoreFromChat(sessionId = 'default') {
-  const res = await fetch('/lore/suggest_from_chat', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ session_id: sessionId }) });
+  const res = await fetch(`${API_BASE}/lore/suggest_from_chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ session_id: sessionId }) });
   if (!res.ok) throw new Error(`Suggest lore failed: ${res.status}`);
   return res.json(); // { suggestions: [{ keyword, content }] }
 }
 
 // Tools / MCP
 export async function getMcpServers() {
-  const res = await fetch('/tools/mcp');
+  const res = await fetch(`${API_BASE}/tools/mcp`);
   if (!res.ok) throw new Error(`Get MCP servers failed: ${res.status}`);
   return res.json(); // { servers: [] }
 }
 export async function saveMcpServers(data) {
-  const res = await fetch('/tools/mcp', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+  const res = await fetch(`${API_BASE}/tools/mcp`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
   if (!res.ok) throw new Error(`Save MCP servers failed: ${res.status}`);
   return res.json();
 }
 
 export async function getMcpAwesome() {
-  const res = await fetch('/tools/mcp/awesome');
+  const res = await fetch(`${API_BASE}/tools/mcp/awesome`);
   if (!res.ok) throw new Error(`Fetch MCP awesome failed: ${res.status}`);
   return res.json(); // { items: [{name,url,description}] }
 }
 
 // Tool settings
 export async function getToolSettings() {
-  const res = await fetch('/tools/settings');
+  const res = await fetch(`${API_BASE}/tools/settings`);
   if (!res.ok) throw new Error(`Get tool settings failed: ${res.status}`);
   return res.json();
 }
 export async function saveToolSettings(data) {
-  const res = await fetch('/tools/settings', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+  const res = await fetch(`${API_BASE}/tools/settings`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
   if (!res.ok) throw new Error(`Save tool settings failed: ${res.status}`);
   return res.json();
 }

--- a/frontend/src/components/lorebook/ActiveLorebooks.tsx
+++ b/frontend/src/components/lorebook/ActiveLorebooks.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { API_BASE } from '../../api.js';
 
 interface Lorebook {
   id: number;
@@ -16,7 +17,7 @@ const ActiveLorebooks: React.FC<ActiveLorebooksProps> = ({ lorebooks }) => {
   useEffect(() => {
     const loadActiveIds = async () => {
       try {
-        const response = await fetch('/config');
+        const response = await fetch(`${API_BASE}/config`);
         if (response.ok) {
           const cfg = await response.json();
           setActiveIds(cfg.active_lorebook_ids || []);
@@ -33,7 +34,7 @@ const ActiveLorebooks: React.FC<ActiveLorebooksProps> = ({ lorebooks }) => {
     const newList = [...activeIds, id];
     setActiveIds(newList);
     try {
-      await fetch('/config/active_lorebook_ids', {
+      await fetch(`${API_BASE}/config/active_lorebook_ids`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids: newList })
@@ -47,7 +48,7 @@ const ActiveLorebooks: React.FC<ActiveLorebooksProps> = ({ lorebooks }) => {
     const newList = activeIds.filter(x => x !== id);
     setActiveIds(newList);
     try {
-      await fetch('/config/active_lorebook_ids', {
+      await fetch(`${API_BASE}/config/active_lorebook_ids`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids: newList })

--- a/frontend/src/components/lorebook/LorebookDashboard.tsx
+++ b/frontend/src/components/lorebook/LorebookDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useLorebookStore } from '../../stores/lorebookStore';
+import { API_BASE } from '../../api.js';
 import { Lorebook, LoreEntry } from '../../stores/lorebookStore';
 import { LorebookGrid } from './LorebookGrid';
 import { LorebookSearch } from './LorebookSearch';
@@ -63,7 +64,7 @@ const LorebookDashboard: React.FC = () => {
     setEditingLorebook(lorebook);
     try {
       // Load the lorebook entries for editing using API directly
-      const lorebookData = await fetch(`/lorebooks/${lorebook.id}`);
+      const lorebookData = await fetch(`${API_BASE}/lorebooks/${lorebook.id}`);
       if (lorebookData.ok) {
         const data = await lorebookData.json();
         setEditingLorebookEntries(data.entries || []);
@@ -91,7 +92,7 @@ const LorebookDashboard: React.FC = () => {
       const originalEntries = editingLorebookEntries;
 
       // Load current entries from server for comparison
-      const currentResponse = await fetch(`/lorebooks/${editingLorebook.id}`);
+      const currentResponse = await fetch(`${API_BASE}/lorebooks/${editingLorebook.id}`);
       if (!currentResponse.ok) {
         throw new Error('Failed to load current entries');
       }
@@ -142,7 +143,7 @@ const LorebookDashboard: React.FC = () => {
             order: entry.order
           };
 
-          await fetch('/lorebooks/entries', {
+          await fetch(`${API_BASE}/lorebooks/entries`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(newEntryData)
@@ -165,7 +166,7 @@ const LorebookDashboard: React.FC = () => {
             order: entry.order
           };
 
-          await fetch(`/lorebooks/entries/${entry.id}`, {
+          await fetch(`${API_BASE}/lorebooks/entries/${entry.id}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(updateData)
@@ -178,7 +179,7 @@ const LorebookDashboard: React.FC = () => {
       // Delete removed entries
       for (const entryId of toDelete) {
         try {
-          await fetch(`/lorebooks/entries/${entryId}`, {
+          await fetch(`${API_BASE}/lorebooks/entries/${entryId}`, {
             method: 'DELETE'
           });
         } catch (error) {

--- a/frontend/src/debug.js
+++ b/frontend/src/debug.js
@@ -3,6 +3,7 @@
  *
  * Loads and manages debug configurations from debug.json file.
  */
+import { API_BASE } from './api.js';
 
 class DebugLogger {
   constructor() {
@@ -22,7 +23,7 @@ class DebugLogger {
     }
 
     try {
-      const response = await fetch('/debug.json');
+      const response = await fetch(`${API_BASE}/debug.json`);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }

--- a/frontend/src/pluginHost.js
+++ b/frontend/src/pluginHost.js
@@ -1,4 +1,5 @@
 // Simple plugin host for CoolChat frontend
+import { API_BASE } from './api.js';
 
 const state = {
   backgroundAnimations: [], // [{ id, label }]
@@ -76,7 +77,7 @@ export async function loadPlugins(manifestData) {
       plugins = Array.isArray(manifestData.plugins) ? manifestData.plugins : [];
       enabled = manifestData.enabled || {};
     } else {
-      const res = await fetch('/plugins');
+      const res = await fetch(`${API_BASE}/plugins`);
       if (!res.ok) {
         console.warn('Failed to fetch /plugins');
         return;
@@ -105,7 +106,7 @@ export async function loadPlugins(manifestData) {
       }
       try {
         const entry = p?.client?.entry || 'plugin.js';
-        const url = `/plugins/static/${p.id}/${entry}`;
+        const url = `${API_BASE}/plugins/static/${p.id}/${entry}`;
         // Vite needs @vite-ignore for fully dynamic imports
         console.log('Loading plugin:', p.id, 'from', url);
         const mod = await import(/* @vite-ignore */ url);

--- a/frontend/src/stores/dataStore.ts
+++ b/frontend/src/stores/dataStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { listCharacters, deleteCharacter, listLorebooks, updateLoreEntry, getLorebook } from '../api.js';
+import { listCharacters, deleteCharacter, listLorebooks, updateLoreEntry, getLorebook, API_BASE } from '../api.js';
 
 export interface DataState {
   // Characters
@@ -154,7 +154,7 @@ export const useDataStore = create<DataState>((set, get) => ({
 
       if (persist) {
         // Persist to backend if available
-        const response = await fetch('/plugins/enabled', {
+        const response = await fetch(`${API_BASE}/plugins/enabled`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ enabled }),

--- a/frontend/src/test.setup.js
+++ b/frontend/src/test.setup.js
@@ -1,2 +1,9 @@
-import '@testing-library/jest-dom';
+import { expect } from 'vitest';
+
+// Expose expect before loading jest-dom
+global.expect = expect;
+await import('@testing-library/jest-dom');
+
+// Provide a predictable API base for tests
+import.meta.env.VITE_API_BASE = 'http://test';
 


### PR DESCRIPTION
## Summary
- add VITE_API_BASE-driven API base URL and prepend to fetch calls
- document API base override for production
- adapt tests to stub the API base

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfa64af68483328d098503e082723d