### PR TITLE
Add foundational circuits system with editor skeleton

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -22,7 +22,7 @@ from .models import Lorebook, LoreEntry, Character as CharacterModel
 from .storage import load_json, save_json, public_dir
 from .database import SessionLocal, get_db
 from sqlalchemy.orm import Session
-from .routers import lore
+from .routers import lore, circuits
 import os
 
 app = FastAPI(title="CoolChat")
@@ -76,6 +76,7 @@ except Exception:
 # Include routers
 # Include routers
 app.include_router(lore.router, tags=["lore"])
+app.include_router(circuits.router, tags=["circuits"])
 
 # Characters router not included - using direct endpoints instead to avoid model conflicts
 # app.include_router(characters.router, tags=["characters"])

--- a/backend/models.py
+++ b/backend/models.py
@@ -136,6 +136,18 @@ class LoreEntry(Base):
     lorebook = relationship("Lorebook", back_populates="entries", lazy="joined")
 
 
+class Circuit(Base):
+    """Stored prompt circuit definitions."""
+    __tablename__ = "circuits"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    data = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+
+
 class RAGConfig(Base):
     """Configuration for RAG embedding service"""
     __tablename__ = "rag_config"

--- a/backend/routers/circuits.py
+++ b/backend/routers/circuits.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..database import get_db
+
+router = APIRouter(prefix="/circuits")
+
+@router.get("/", response_model=list[schemas.Circuit])
+def list_circuits(db: Session = Depends(get_db)):
+    return db.query(models.Circuit).all()
+
+@router.post("/", response_model=schemas.Circuit, status_code=201)
+def create_circuit(payload: schemas.CircuitCreate, db: Session = Depends(get_db)):
+    circuit = models.Circuit(**payload.dict())
+    db.add(circuit)
+    db.commit()
+    db.refresh(circuit)
+    return circuit
+
+@router.get("/{circuit_id}", response_model=schemas.Circuit)
+def get_circuit(circuit_id: int, db: Session = Depends(get_db)):
+    circuit = db.query(models.Circuit).get(circuit_id)
+    if not circuit:
+        raise HTTPException(status_code=404, detail="Circuit not found")
+    return circuit
+
+@router.put("/{circuit_id}", response_model=schemas.Circuit)
+def update_circuit(circuit_id: int, payload: schemas.CircuitCreate, db: Session = Depends(get_db)):
+    circuit = db.query(models.Circuit).get(circuit_id)
+    if not circuit:
+        raise HTTPException(status_code=404, detail="Circuit not found")
+    for k, v in payload.dict().items():
+        setattr(circuit, k, v)
+    db.commit()
+    db.refresh(circuit)
+    return circuit
+
+@router.delete("/{circuit_id}", status_code=204)
+def delete_circuit(circuit_id: int, db: Session = Depends(get_db)):
+    circuit = db.query(models.Circuit).get(circuit_id)
+    if not circuit:
+        raise HTTPException(status_code=404, detail="Circuit not found")
+    db.delete(circuit)
+    db.commit()
+    return None

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from datetime import datetime
 
 
 class CharacterCardBase(BaseModel):
@@ -13,6 +14,25 @@ class CharacterCardCreate(CharacterCardBase):
 
 class CharacterCard(CharacterCardBase):
     id: int
+
+    class Config:
+        orm_mode = True
+
+
+class CircuitBase(BaseModel):
+    name: str
+    description: str | None = None
+    data: dict
+
+
+class CircuitCreate(CircuitBase):
+    pass
+
+
+class Circuit(CircuitBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
 
     class Config:
         orm_mode = True

--- a/backend/tests/test_circuits.py
+++ b/backend/tests/test_circuits.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.database import create_tables
+
+create_tables()
+
+client = TestClient(app)
+
+
+def test_circuit_crud_cycle():
+    resp = client.get("/circuits/")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+    payload = {"name": "Test", "description": "desc", "data": {"nodes": []}}
+    resp = client.post("/circuits/", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    cid = data["id"]
+    assert data["name"] == payload["name"]
+
+    resp = client.get(f"/circuits/{cid}")
+    assert resp.status_code == 200
+    assert resp.json()["data"] == payload["data"]
+
+    update = {"name": "Test2", "description": "d2", "data": {"nodes": [1]}}
+    resp = client.put(f"/circuits/{cid}", json=update)
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Test2"
+
+    resp = client.delete(f"/circuits/{cid}")
+    assert resp.status_code == 204
+
+    resp = client.get(f"/circuits/{cid}")
+    assert resp.status_code == 404

--- a/frontend/src/components/circuits/CircuitEditor.css
+++ b/frontend/src/components/circuits/CircuitEditor.css
@@ -1,0 +1,33 @@
+.circuit-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.editor-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 200px 1fr 250px;
+  gap: 8px;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.toolbar {
+  padding: 8px;
+  border-bottom: 1px solid var(--muted);
+}
+
+.block-palette,
+.canvas,
+.properties {
+  background: var(--panel);
+  border: 1px solid var(--muted);
+  border-radius: 8px;
+  overflow: auto;
+  padding: 8px;
+}
+
+.title {
+  font-weight: 600;
+}

--- a/frontend/src/components/circuits/CircuitEditor.tsx
+++ b/frontend/src/components/circuits/CircuitEditor.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react';
+import { useCircuitStore } from '../../stores/circuitStore';
+import './CircuitEditor.css';
+
+export const CircuitEditor: React.FC = () => {
+  const { circuits, current, fetchCircuits } = useCircuitStore();
+
+  useEffect(() => {
+    fetchCircuits();
+  }, [fetchCircuits]);
+
+  return (
+    <div className="circuit-editor">
+      <div className="toolbar panel">
+        <span className="title">Circuits</span>
+      </div>
+      <div className="editor-body">
+        <aside className="block-palette panel">Block Palette</aside>
+        <main className="canvas panel">
+          {current ? (
+            <pre>{JSON.stringify(current.data, null, 2)}</pre>
+          ) : (
+            <div className="muted">Select or create a circuit</div>
+          )}
+        </main>
+        <aside className="properties panel">Properties</aside>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/stores/circuitStore.ts
+++ b/frontend/src/stores/circuitStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { API_BASE } from '../api';
+
+export interface Circuit {
+  id?: number;
+  name: string;
+  description?: string;
+  data: object;
+}
+
+interface CircuitState {
+  circuits: Circuit[];
+  current?: Circuit;
+  fetchCircuits: () => Promise<void>;
+  saveCircuit: (c: Circuit) => Promise<void>;
+}
+
+export const useCircuitStore = create<CircuitState>((set, get) => ({
+  circuits: [],
+  async fetchCircuits() {
+    const res = await fetch(`${API_BASE}/circuits/`);
+    const data = await res.json();
+    set({ circuits: data });
+  },
+  async saveCircuit(circuit) {
+    const res = await fetch(`${API_BASE}/circuits/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(circuit),
+    });
+    if (!res.ok) throw new Error('Failed to save');
+    const saved = await res.json();
+    set({ circuits: [...get().circuits, saved], current: saved });
+  },
+}));


### PR DESCRIPTION
## Summary
- add `Circuit` model and CRUD API endpoints
- wire circuits router into FastAPI app
- introduce Zustand circuit store and basic CircuitEditor component using app theme
- test circuits API

## Testing
- `pytest backend/tests/test_circuits.py -q`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfb58f3fc88332946d1d3efb32138e